### PR TITLE
Implement witness addresses, p2sh and various other minor fixes

### DIFF
--- a/install-dev-prerequisites.sh
+++ b/install-dev-prerequisites.sh
@@ -1,4 +1,4 @@
-npm install -g @angular/cli
+sudo npm install -g @angular/cli
 cd electron
 npm install
 cd ../middleware

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "async": "^2.5.0",
     "body-parser": "~1.17.1",
+    "bech32" : "latest",
     "cookie-parser": "~1.4.3",
     "debug": "~2.6.3",
     "express": "~4.15.2",

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -18,6 +18,8 @@
     "levelup": "^1.3.9",
     "morgan": "~1.8.1",
     "node-lmdb": "^0.4.13",
+    "leveldown": "latest",
+    "levelup": "latest",
     "request": "^2.81.0",
     "serve-favicon": "~2.4.2",
     "uuid": "^3.1.0"

--- a/middleware/services/blockchainindexing.js
+++ b/middleware/services/blockchainindexing.js
@@ -3,7 +3,8 @@ const path = require('path');
 const ini = require('ini');
 const uuidv4 = require('uuid/v4');
 const async = require('async');
-const lmdb = require('node-lmdb');
+//const lmdb = require('node-lmdb');
+const levelup = require('levelup');
 
 var blockchainIndexing = {};
 
@@ -22,7 +23,8 @@ var ensureIndexFolder = function(callback) {
 
 var setup = function(callback) {
   var indexDir = path.join(__dirname, '..', 'blockchainIndex');
-  blockchainIndexing.env = new lmdb.Env();
+  blockchainIndexing.db = levelup(indexDir);
+  /*blockchainIndexing.env = new lmdb.Env();
   blockchainIndexing.env.open({
       path: indexDir,
       mapSize: 20*1024*1024*1024, // maximum database size
@@ -31,7 +33,7 @@ var setup = function(callback) {
   blockchainIndexing.db = blockchainIndexing.env.openDbi({
       name: "blockchainIndexDb",
       create: true // will create if database did not exist
-  });
+  });*/
   callback();
 }
 
@@ -39,38 +41,63 @@ var processTx = function(hash, callback) {
   //console.log("Processing TX: ", hash);
   blockchainIndexing.vertcoind.request('getrawtransaction', [hash, true], function(err, result, body) {
     //blockchainIndexing.vertcoind.request('decoderawtransaction', [body.result], function(err, result, body) {
-      if(body.result) {
+      if(!err && body.result) {
         for(var i = 0; i < body.result.vin.length; i++) {
           var txi = body.result.vin[i];
           if(txi.txid) {
             // Mark the output as spent
-            var txn = blockchainIndexing.env.beginTxn();
-            var value = txn.getString(blockchainIndexing.db, "txo-" + txi.txid + "-" + txi.vout);
-            if(!value) { console.log("Error: VIN using a non-existing TXO"); }
+            //var txn = blockchainIndexing.env.beginTxn();
+            //var value = txn.getString(blockchainIndexing.db, "txo-" + txi.txid + "-" + txi.vout);
+            blockchainIndexing.db.get("txo-" + txi.txid + "-" + txi.vout, function(error, value) {
+                if(error) { 
+                    console.log("Error: VIN using a non-existing TXO", txi.txid);
+                    blockchainIndexing.timeout = setTimeout(processTx, 10, hash, callback);
+                    return;
+                } else {
+                
+                    txo = JSON.parse(value);
+                    txo.spent = true;
+                    txo.spentTxID = hash;
+                    blockchainIndexing.db.put("txo-" + txi.txid + "-" + txi.vout, JSON.stringify(txo), {"sync": true});
+                }        
+            });
+            /*if(!value) { console.log("Error: VIN using a non-existing TXO"); }
             txo = JSON.parse(value);
             txo.spent = true;
             txo.spentTxID = hash;
             txn.putString(blockchainIndexing.db, "txo-" + txi.txid + "-" + txi.vout, JSON.stringify(txo));
-            txn.commit();
+            txn.commit();*/
+            
           }
         }
         for(var i = 0; i < body.result.vout.length; i++) {
+            var curTxo = i;
           if(!body.result.vout[i].scriptPubKey) {
             console.log("No scriptPubKey!", body.result.vout[i]);
           } else {
             switch(body.result.vout[i].scriptPubKey.type) {
               case 'pubkey':
               case 'pubkeyhash':
-                for(var j = 0; j < body.result.vout[i].scriptPubKey.addresses.length; j++) {
+                for(var j = 0; j < body.result.vout[i].scriptPubKey.addresses.length; j++) {               
                   var addr = body.result.vout[i].scriptPubKey.addresses[j];
-                  var txn = blockchainIndexing.env.beginTxn();
-                  var value = txn.getString(blockchainIndexing.db, addr + "-txos");
+                  //var txn = blockchainIndexing.env.beginTxn();
+                  blockchainIndexing.db.get(addr + "-txos", function(error, value) {
+                      var txos = [];
+                      if(!error && value) {
+                          txos = JSON.parse(value);
+                      }
+                      
+                      txos.push({txid : hash, vout : curTxo});
+                      blockchainIndexing.db.batch([{type: 'put', key: addr + "-txos", value: JSON.stringify(txos)},
+                      {type: 'put', key: "txo-" + hash + "-" + i, value: JSON.stringify({value:body.result.vout[curTxo].value})}], {"sync": true});
+                  });
+                  /*var value = txn.getString(blockchainIndexing.db, addr + "-txos");
                   var txos = [];
                   if(value) txos = JSON.parse(value);
                   txos.push({txid : hash, vout : i});
                   txn.putString(blockchainIndexing.db, addr + "-txos", JSON.stringify(txos));
                   txn.putString(blockchainIndexing.db, "txo-" + hash + "-" + i, JSON.stringify({value:body.result.vout[i].value}))
-                  txn.commit();
+                  txn.commit();*/
 
                 }
                 break;
@@ -83,8 +110,13 @@ var processTx = function(hash, callback) {
           }
           //console.log("Found vout", );
         }
+        
+        callback();
+      } else {
+        console.log("Error", err);
+        blockchainIndexing.timeout = setTimeout(processTx, 10, hash, callback);
+        return;
       }
-      callback();
     //});
   });
 }
@@ -94,19 +126,32 @@ var processBlock = function(index, callback) {
   if(index % 1000 === 0)
     console.log("Processing block", index);
   blockchainIndexing.vertcoind.request('getblockhash', [index], function(err, result, body) {
+    if(!err && body.result) {
     blockchainIndexing.vertcoind.request('getblock', [body.result], function(err, result, body) {
-      var txQueue = async.queue(processTx, 1);
-      txQueue.drain = function() {
-        var txn = blockchainIndexing.env.beginTxn();
-        var value = txn.putString(blockchainIndexing.db, "lastBlock", index);
-        txn.commit();
-        callback();
-      };
-      for(i = 0; i < body.result.tx.length; i++) {
-        txQueue.push(body.result.tx[i]);
+      if(!err && body.result) {
+          //console.log(body.result);
+          var txQueue = async.queue(processTx, 1);
+          txQueue.drain = function() {
+            //var txn = blockchainIndexing.env.beginTxn();
+            blockchainIndexing.db.put("lastBlock", index, {"sync": true});        
+            //var value = txn.putString(blockchainIndexing.db, "lastBlock", index);
+            //txn.commit();
+            callback();
+          };
+          for(i = 0; i < body.result.tx.length; i++) {
+            txQueue.push(body.result.tx[i]);
+          }
+      } else {
+        console.log("Error", err);
+        blockchainIndexing.timeout = setTimeout(processBlock, 10, index, callback);
+        return;
       }
     });
-
+    } else {
+        console.log("Error", err);
+        blockchainIndexing.timeout = setTimeout(processBlock, 10, index, callback);
+        return;
+    }
   });
 
 
@@ -119,12 +164,51 @@ var processIndexes = function() {
     blockchainIndexing.timeout = setTimeout(processIndexes, 1000);
     return;
   }
+  
+  blockchainIndexing.vertcoind.request('getblockchaininfo', [], function(err, result, body) {
+    if(err) {
+        console.log("Error", err);
+        blockchainIndexing.timeout = setTimeout(processIndexes, 1000);
+        return;
+    }
+    
+    if(body.result.verificationprogress < 0.999) {
+        console.log("vertcoind not yet synced, waiting. Progress: " + body.result.verificationprogress);
+        blockchainIndexing.timeout = setTimeout(processIndexes, 1000 * 120);
+        return;
+    }
+    
+    blockchainIndexing.db.get("lastBlock", function(error, value) {
+      if(error) {
+        value = 0;
+      }
+      
+      value = parseInt(value);
+      
+      var startBlock = value;
+    console.log("Starting building additional indexes from block: ",value);
+    blockchainIndexing.vertcoind.request('getblockcount', [], function(err, result, body) {
+      var blockQueue = async.queue(processBlock, 1);
+      blockQueue.drain = function() {
+        blockchainIndexing.timeout = setTimeout(processIndexes, 1000);
+      };
+      if(startBlock == body.result)
+        blockQueue.drain();
+      else
+        for(i = startBlock + 1; i <= body.result; i++) {
+          blockQueue.push(i);
+        }
 
-  var txn = blockchainIndexing.env.beginTxn();
-  var value = txn.getString(blockchainIndexing.db, "lastBlock");
-  txn.commit();
+    });
+  });
+  });
 
-  if(!value) value = -1;
+  //var txn = blockchainIndexing.env.beginTxn();
+  //var value = txn.getString(blockchainIndexing.db, "lastBlock");
+  //txn.commit();
+ 
+
+  /*if(!value) value = -1;
   else value = parseInt(value);
 
     var startBlock = value;
@@ -141,7 +225,7 @@ var processIndexes = function() {
           blockQueue.push(i);
         }
 
-    });
+    });*/
 
 };
 

--- a/middleware/services/vertcoind.js
+++ b/middleware/services/vertcoind.js
@@ -63,7 +63,8 @@ vertcoind.request = function(method, params, callback, retry) {
         body = JSON.parse(body);
       } catch (e) {
         console.log("Error parsing JSON",e,"\r\nJSON:\r\n",body);
-
+        vertcoind.request(method, params, callback, retry);
+        return;
       }
       callback(err, result, body);
     }
@@ -159,6 +160,7 @@ var checkRpcConfig = function(callback) {
   if(!config.rpcuser || !config.rpcpassword) {
     config.rpcuser = 'vertcoinrpc';
     config.rpcpassword = uuidv4();
+    config.rpcworkqueue = 64;
   }
 
   fs.writeFileSync(vertcoindConfigFile, ini.stringify(config));

--- a/middleware/services/vertcoind.js
+++ b/middleware/services/vertcoind.js
@@ -54,11 +54,11 @@ vertcoind.request = function(method, params, callback) {
   request.post('http://localhost:5888/',{ 'auth' : {
     user : vertcoind.rpcUser,
     pass : vertcoind.rpcPassword
-  }, 'body' : JSON.stringify(requestBody)}, function(err, result, body) {
+  }, 'body' : JSON.stringify(requestBody), 'timeout': 3000}, function(err, result, body) {
     try {
       body = JSON.parse(body);
     } catch (e) {
-      console.log("Error parsing JSON",e);
+      console.log("Error parsing JSON", e, body);
     }
     callback(err, result, body);
   });
@@ -78,7 +78,7 @@ var checkJsonRPCAvailable = function(callback) {
 
 var startNode = function(callback) {
   var process = path.join(__dirname, '..', 'vertcoind' , processName);
-  var arguments = ['--txindex','--datadir=' + path.join(__dirname, '..', 'vertcoind', 'data'), '-disablewallet'];
+  var arguments = ['-txindex','--datadir=' + path.join(__dirname, '..', 'vertcoind', 'data'), '-disablewallet'];
   vertcoind.nodeProcess = spawn(process, arguments);
   vertcoind.nodeProcess.stdout.on('data', (data) => {
     console.log(`vertcoind [out]: ${data}`);

--- a/middleware/services/vertcoind.js
+++ b/middleware/services/vertcoind.js
@@ -78,7 +78,7 @@ var checkJsonRPCAvailable = function(callback) {
 
 var startNode = function(callback) {
   var process = path.join(__dirname, '..', 'vertcoind' , processName);
-  var arguments = ['--txindex','--datadir=' + path.join(__dirname, '..', 'vertcoind', 'data')];
+  var arguments = ['--txindex','--datadir=' + path.join(__dirname, '..', 'vertcoind', 'data'), '-disablewallet'];
   vertcoind.nodeProcess = spawn(process, arguments);
   vertcoind.nodeProcess.stdout.on('data', (data) => {
     console.log(`vertcoind [out]: ${data}`);


### PR DESCRIPTION
- uses bech32 to encode p2wpkh and p2wsh addresses with the 'vtc' prefix
- indexes p2sh txos
- auto-retries failed index calls to vertcoind
- ensures vertcoind is synced before attempting to build the index
- increases the vertcoind worksize queue